### PR TITLE
Changed license badge URI and color

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Easy Metafile Manager
 + [![NPM Version](http://img.shields.io/npm/v/chest.svg)](https://www.npmjs.org/package/chest)
 + [![Build Status](https://api.travis-ci.org/watilde/chest.svg)](https://travis-ci.org/watilde/chest)
 + [![Dependency Status](https://gemnasium.com/watilde/chest.svg)](https://gemnasium.com/watilde/chest)
-+ [![MIT LICENSE](http://img.shields.io/packagist/l/doctrine/orm.svg)](https://github.com/watilde/chest/blob/master/LICENSE)
++ [![MIT LICENSE](http://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/watilde/chest/blob/master/LICENSE)
 
 
 ## Install


### PR DESCRIPTION
- [x] Changed badge URI to shields.io's plain badge URI, not the packagist one.
- [x] Additionally, changed badge color to brightgreen (for the MIT license, What do you think?)

Thanks!
